### PR TITLE
feat: circle & cross pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Tic Tac Toe Rust
 
 Making a simple game of [Tic Tac Toe](https://wikipedia.org/wiki/Tic-tac-toe) in Rust using the sdl (v2) [Rust Crate](https://crates.io/crates/sdl2).
+
+## Attributes
+
+- [Draw a circle with Rust](https://gist.github.com/MetroWind/352bd75c363928f5c0009276af1b7928)

--- a/src/click.rs
+++ b/src/click.rs
@@ -2,7 +2,12 @@ use crate::board::Board;
 use crate::turn::PlayerTurn;
 
 /// Run when a player clicks the board
-pub fn click(board: &Board, turn: &PlayerTurn, x_coord: i32, y_coord: i32) -> Result<Board, String> {
+pub fn click(
+	board: &Board,
+	turn: &PlayerTurn,
+	x_coord: i32,
+	y_coord: i32,
+) -> Result<Board, String> {
 	let slot = get_slot(x_coord, y_coord).unwrap();
 
 	if !board.slot_available(slot) {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -98,6 +98,14 @@ impl Renderer {
 		Ok(())
 	}
 
+	/// Draw cross piece
+	fn draw_cross(&mut self, center: SDLPoint) -> Result<(), String> {
+		self.canvas.draw_line(SDLPoint::new(center.x - 100, center.y - 125), SDLPoint::new(center.x + 100, center.y + 125))?;
+		self.canvas.draw_line(SDLPoint::new(center.x + 100, center.y - 125), SDLPoint::new(center.x - 100, center.y + 125))?;
+
+		Ok(())
+	}
+
 	/// Draw player's piece
 	fn draw_player(&mut self, slot: usize, player: PlayerTurn) -> Result<(), String> {
 		match player {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -2,6 +2,7 @@ use crate::board::{Board, Slot};
 use crate::turn::PlayerTurn;
 
 use sdl2::pixels::Color;
+use sdl2::rect::Point as SDLPoint;
 use sdl2::rect::Rect;
 use sdl2::render::WindowCanvas;
 use sdl2::video::Window;
@@ -51,6 +52,48 @@ impl Renderer {
 
 		self.draw_horizontal_line(1000, &Point(100, 400))?;
 		self.draw_horizontal_line(1000, &Point(100, 800))?;
+
+		Ok(())
+	}
+
+	/// Draw a circle piece
+	fn draw_cirle(&mut self, center: SDLPoint) -> Result<(), String> {
+		let radius = 100;
+
+		let mut x = radius;
+		let mut y = 0;
+
+		let mut re = x * x + y * y - radius * radius;
+
+		while x >= y {
+			self.canvas
+				.draw_point(SDLPoint::new(center.x + x, center.y + y))?;
+			self.canvas
+				.draw_point(SDLPoint::new(center.x + y, center.y + x))?;
+
+			self.canvas
+				.draw_point(SDLPoint::new(center.x + x, center.y - y))?;
+			self.canvas
+				.draw_point(SDLPoint::new(center.x + y, center.y - x))?;
+
+			self.canvas
+				.draw_point(SDLPoint::new(center.x - x, center.y + y))?;
+			self.canvas
+				.draw_point(SDLPoint::new(center.x - y, center.y + x))?;
+
+			self.canvas
+				.draw_point(SDLPoint::new(center.x - x, center.y - y))?;
+			self.canvas
+				.draw_point(SDLPoint::new(center.x - y, center.y - x))?;
+
+			if 2 * (re + 2 * y + 1) + 1 - 2 * x > 0 {
+				re += 1 - 2 * x;
+				x -= 1;
+			}
+
+			re += 2 * y + 1;
+			y += 1;
+		}
 
 		Ok(())
 	}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -119,32 +119,86 @@ impl Renderer {
 		}
 
 		match slot {
-			0 => {
-				self.canvas.fill_rect(Rect::new(150, 150, 100, 100))?;
+			0 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(250, 250))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(250, 250))?;
+				}
+				_ => {}
+			},
+			1 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(600, 250))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(600, 250))?;
+				}
+				_ => {}
 			}
-			1 => {
-				self.canvas.fill_rect(Rect::new(550, 150, 100, 100))?;
+			2 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(950, 250))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(950, 250))?;
+				}
+				_ => {}
 			}
-			2 => {
-				self.canvas.fill_rect(Rect::new(950, 150, 100, 100))?;
+			3 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(250, 600))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(250, 600))?;
+				}
+				_ => {}
 			}
-			3 => {
-				self.canvas.fill_rect(Rect::new(150, 550, 100, 100))?;
+			4 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(600, 600))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(600, 600))?;
+				}
+				_ => {}
 			}
-			4 => {
-				self.canvas.fill_rect(Rect::new(550, 550, 100, 100))?;
+			5 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(950, 600))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(950, 600))?;
+				}
+				_ => {}
 			}
-			5 => {
-				self.canvas.fill_rect(Rect::new(950, 550, 100, 100))?;
+			6 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(250, 950))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(250, 950))?;
+				}
+				_ => {}
 			}
-			6 => {
-				self.canvas.fill_rect(Rect::new(150, 950, 100, 100))?;
+			7 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(600, 950))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(600, 950))?;
+				}
+				_ => {}
 			}
-			7 => {
-				self.canvas.fill_rect(Rect::new(550, 950, 100, 100))?;
-			}
-			8 => {
-				self.canvas.fill_rect(Rect::new(950, 950, 100, 100))?;
+			8 => match player {
+				PlayerTurn::PlayerOne => {
+					self.draw_cirle(SDLPoint::new(950, 950))?;
+				}
+				PlayerTurn::PlayerTwo => {
+					self.draw_cross(SDLPoint::new(950, 950))?;
+				}
+				_ => {}
 			}
 			_ => {}
 		}


### PR DESCRIPTION
- **feat: draw circle renderer helper function**
- **chore: `cargo fmt`**
- **feat: add draw cross renderer fn**
- **feat: switch to using cross and circle rendering for players**
- **docs: give credit to draw circle gist**
